### PR TITLE
Add brew bundle command to install MacOS dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ os:
   - linux
   - osx
 
+addons:
+  homebrew:
+    brewfile: true
+
 dist: bionic
 
 sudo: required

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+brew "libusb"

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -29,8 +29,8 @@ It is recommended that you install brew and xcode.
 
 Additionally you will need to:
 
-```
-brew install libusb
+```sh
+brew bundle
 ```
 
 ### Python 3 development environment

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -60,12 +60,7 @@ if [[ "$MODE" == "unit" ]]; then
   # Install dependencies
   #
   fold_start "install-dependencies"
-  if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
-    make deps
-  else
-    brew install libusb
-    make deps
-  fi
+  make deps
   fold_end
 
   #


### PR DESCRIPTION
On previous builds `brew install libusb` threw an error because `libusb` is already installed. `brew bundle` command not only solves the problem also makes MacOS dependency installation easier.